### PR TITLE
Use CF when one is passed to Remove

### DIFF
--- a/RocksDbSharp/Native.Wrap.cs
+++ b/RocksDbSharp/Native.Wrap.cs
@@ -202,6 +202,18 @@ namespace RocksDbSharp
                 throw new RocksDbException(errptr);
         }
 
+        public void rocksdb_delete_cf(
+            /*rocksdb_t**/ IntPtr db,
+            /*const rocksdb_writeoptions_t**/ IntPtr writeOptions,
+            /*const*/ byte[] key,
+            long keylen,
+            ColumnFamilyHandle cf)
+        {
+            rocksdb_delete_cf(db, writeOptions, cf.Handle, key, keylen, out IntPtr errptr);
+            if (errptr != IntPtr.Zero)
+                throw new RocksDbException(errptr);
+        }
+
         public void rocksdb_write(
             /*rocksdb_t**/ IntPtr db,
             /*const rocksdb_writeoptions_t**/ IntPtr writeOptions,

--- a/RocksDbSharp/RocksDb.cs
+++ b/RocksDbSharp/RocksDb.cs
@@ -152,7 +152,10 @@ namespace RocksDbSharp
 
         public void Remove(byte[] key, long keyLength, ColumnFamilyHandle cf = null, WriteOptions writeOptions = null)
         {
-            Native.Instance.rocksdb_delete(Handle, (writeOptions ?? DefaultWriteOptions).Handle, key, keyLength);
+            if (cf == null)
+                Native.Instance.rocksdb_delete(Handle, (writeOptions ?? DefaultWriteOptions).Handle, key, keyLength);
+            else
+                Native.Instance.rocksdb_delete_cf(Handle, (writeOptions ?? DefaultWriteOptions).Handle, key, keyLength, cf);
         }
 
         public void Put(string key, string value, ColumnFamilyHandle cf = null, WriteOptions writeOptions = null, Encoding encoding = null)

--- a/tests/RocksDbSharpTest/FunctionalTests.cs
+++ b/tests/RocksDbSharpTest/FunctionalTests.cs
@@ -166,6 +166,25 @@ namespace RocksDbSharpTest
                 db.Put("tres", "three", cf: reverse);
             }
 
+            // Test Cf Delete
+            using (var db = RocksDb.Open(optionsCf, path, columnFamilies))
+            {
+                var reverse = db.GetColumnFamily("reverse");
+
+                db.Put("cuatro", "four", cf: reverse);
+                db.Put("cinco", "five", cf: reverse);
+
+                Assert.Equal("four", db.Get("cuatro", cf: reverse));
+                Assert.Equal("five", db.Get("cinco", cf: reverse));
+
+                byte[] keyBytes = Encoding.UTF8.GetBytes("cuatro");
+                db.Remove(keyBytes, reverse);
+                db.Remove("cinco", reverse);
+
+                Assert.Null(db.Get("cuatro", cf: reverse));
+                Assert.Null(db.Get("cinco", cf: reverse));
+            }
+
             // Test list
             {
                 var list = RocksDb.ListColumnFamilies(optionsCf, path);


### PR DESCRIPTION
The Remove method that takes a key byte[] does not pass the column family handle to the native function. This makes it so that records can't be removed from a column family with a byte[] key.