### PR TITLE
Fix values containing empty strings on .Net standard

### DIFF
--- a/RocksDbSharp/Transitional.cs
+++ b/RocksDbSharp/Transitional.cs
@@ -59,6 +59,10 @@ namespace Transitional
 #if NETSTANDARD1_6
         {           
             int vlength = enc.GetCharCount((byte*)value, length);
+            if (vlength == 0)
+            {
+                return string.Empty;
+            }
             fixed (char* v = new char[vlength])
             {
                 enc.GetChars((byte*)value, length, v, vlength);


### PR DESCRIPTION
enc.GetChars crashes when vlength is 0, ie. when the value of a key is an empty string.

This problem can easily be reproduced on .NET Core/Standard:
`db.Put("key", "");
string value = db.Get("key");`